### PR TITLE
Findargp.cmake rewrote to Modern Cmake. Exported argp::argp target.

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ You found a bug? Please fill out an issue and include any data to reproduce the 
 
 [Alexander Haase](https://github.com/alehaa)
 
+[Krzysztof Tulidowicz](https://github.com/stilgarpl)
+
 
 ## License
 


### PR DESCRIPTION
I tried to update Findargp.cmake to more modern version that would export argp::argp target that would point either to libc or standalone argp. When I noticed that find_library("argp") will actually return libc if it was present, I decided to write a new, much simpler version of Findargp.cmake.